### PR TITLE
reset request.app for each request

### DIFF
--- a/lib/app-context.js
+++ b/lib/app-context.js
@@ -3,18 +3,14 @@
 const fastifyPlugin = require("fastify-plugin");
 
 async function appContext(fastify, opts) {
-  const freshApp = {
-    // Make config available in server.app.config, in addition to
-    // server.settings.app.config
-    config: opts.config
-  };
-  fastify.decorate("app", {...freshApp});
+  const {config} = opts;
+
+  fastify.decorate("app", { config });
   fastify.decorateRequest("app", {});
 
   fastify.addHook("onRequest", (request, reply, done) => {
-    // Provide a copy, so that freshApp cannot get modified
-    // and that request.app is a fresh instance for each new request.
-    request.app = {...freshApp};
+    // Provide new object, so that request.app is a fresh instance for each new request.
+    request.app = { config };
     done();
   });
 }

--- a/lib/app-context.js
+++ b/lib/app-context.js
@@ -4,7 +4,7 @@ const fastifyPlugin = require("fastify-plugin");
 
 async function appContext(fastify, opts) {
   const {config} = opts;
-
+  // Make config available in fastify.app.config, in addition to request.app.config.
   fastify.decorate("app", { config });
   fastify.decorateRequest("app", {});
 

--- a/lib/app-context.js
+++ b/lib/app-context.js
@@ -3,13 +3,20 @@
 const fastifyPlugin = require("fastify-plugin");
 
 async function appContext(fastify, opts) {
-  const app = {
+  const freshApp = {
     // Make config available in server.app.config, in addition to
     // server.settings.app.config
     config: opts.config
   };
-  fastify.decorate("app", app);
-  fastify.decorateRequest("app", app);
+  fastify.decorate("app", {...freshApp});
+  fastify.decorateRequest("app", {});
+
+  fastify.addHook("onRequest", (request, reply, done) => {
+    // Provide a copy, so that freshApp cannot get modified
+    // and that request.app is a fresh instance for each new request.
+    request.app = {...freshApp};
+    done();
+  });
 }
 
 module.exports = fastifyPlugin(appContext, {

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -613,4 +613,28 @@ describe("electrode-server", function() {
     expect(server.hasDecorator("utility")).true;
     expect(server.utility()).eq("bingo");
   });
+
+  it("gets a fresh instance of request.app", async () => {
+    let server;
+    try {
+      server = await electrodeServer({ deferStart: true });
+      server.route({
+        method: "GET",
+        path: "/",
+        handler: (req, reply) => {
+          reply.send(req.app.marker ? "Not Fresh" : "Fresh");
+          req.app.marker = 1;
+        }
+      });
+      await server.start();
+      const { payload: payload1 } = await server.inject({ method: "GET", url: "/" });
+      const { payload: payload2 } = await server.inject({ method: "GET", url: "/" });
+      expect(payload1).to.equal("Fresh");
+      expect(payload2).to.equal("Fresh");
+    } finally {
+      if (server) {
+        stopServer(server);
+      }
+    }
+  });
 });

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -615,26 +615,19 @@ describe("electrode-server", function() {
   });
 
   it("gets a fresh instance of request.app", async () => {
-    let server;
-    try {
-      server = await electrodeServer({ deferStart: true });
-      server.route({
-        method: "GET",
-        path: "/",
-        handler: (req, reply) => {
-          reply.send(req.app.marker ? "Not Fresh" : "Fresh");
-          req.app.marker = 1;
-        }
-      });
-      await server.start();
-      const { payload: payload1 } = await server.inject({ method: "GET", url: "/" });
-      const { payload: payload2 } = await server.inject({ method: "GET", url: "/" });
-      expect(payload1).to.equal("Fresh");
-      expect(payload2).to.equal("Fresh");
-    } finally {
-      if (server) {
-        stopServer(server);
+    server = await electrodeServer({ deferStart: true });
+    server.route({
+      method: "GET",
+      path: "/",
+      handler: (req, reply) => {
+        reply.send(req.app.marker ? "Not Fresh" : "Fresh");
+        req.app.marker = 1;
       }
-    }
+    });
+    await server.start();
+    const { payload: payload1 } = await server.inject({ method: "GET", url: "/" });
+    const { payload: payload2 } = await server.inject({ method: "GET", url: "/" });
+    expect(payload1).to.equal("Fresh");
+    expect(payload2).to.equal("Fresh");
   });
 });

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -622,6 +622,7 @@ describe("electrode-server", function() {
       handler: (req, reply) => {
         reply.send(req.app.marker ? "Not Fresh" : "Fresh");
         req.app.marker = 1;
+        server.app.marker = 1;
       }
     });
     await server.start();


### PR DESCRIPTION
## problem

currently, `request.app` will persist through multiple requests
we want to mimic the behavior of Hapi's `request.app`

e.g. right now:

```
  server.route({
    method: "GET",
    path: "/",
    handler: (req, reply) => {
      if (!req.app.initComplete) {
          performInit(req);
          req.app.initComplete = true;
      }
      reply.send("hello world");
    }
  });
```

`initComplete` gets set to `true` during the first request, and all requests thereafter will not do the initialization logic. This diverges from Hapi's behavior where `request.app` is a fresh object for each request.

## fix

In a `onRequest` hook reset `request.app` to the original object `{ config: appConfig }`

## what's the point of `fastify.decorateRequest` then?

I think it also works if you delete the line `fastify.decorateRequest('app', ...)` in `lib/app-context.js`

but using the `decorateRequest` API allows fastify to optimize for performance, and also probably enables the decorator-dependency-checking feature described [here](https://github.com/fastify/fastify/blob/master/docs/Decorators.md#dependencies)

See https://github.com/fastify/fastify/blob/master/docs/Decorators.md#usage-notes

## concern

I hope that the lifecycle hooks run in the order that they are added, so that subsequent hooks added by other plugins will also have access to the `request.app` object