### PR TITLE
Add boom compatibility

### DIFF
--- a/lib/hapi-compat.js
+++ b/lib/hapi-compat.js
@@ -13,6 +13,18 @@ async function hapiCompat(fastify) {
       return { remoteAddress: this.ip };
     }
   });
+  fastify.setErrorHandler((error, request, reply) => {
+    if (error.isBoom) {
+      reply
+        .code(error.output.statusCode)
+        .type("application/json")
+        .headers(error.output.headers)
+        .send(error.output.payload);
+      return;
+    }
+
+    reply.send(error);
+  });
 }
 
 module.exports = fastifyPlugin(hapiCompat, {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "xaa": "^1.1.4"
   },
   "devDependencies": {
+    "@hapi/boom": "^8.0.1",
     "electrode-archetype-njs-module-dev": "^3.0.0",
     "fastify-static": "^2.5.0",
     "intercept-stdout": "^0.1.2",


### PR DESCRIPTION
Fastify removed boom support at one point: https://github.com/fastify/fastify/issues/542

For compatibility with Hapi plugins, we can just add it in, similar to https://github.com/jeromemacias/fastify-boom/blob/master/index.js