### PR TITLE
locking xaa version to 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.11",
     "pino": "^5.15.0",
     "require-at": "^1.0.1",
-    "xaa": "^1.1.4"
+    "xaa": "1.1.5"
   },
   "devDependencies": {
     "@hapi/boom": "^8.0.1",


### PR DESCRIPTION
fix for https://jira.walmart.com/browse/CEECORE-1297