### PR TITLE
Replaces xaa.map with Promise.all for plugin registration

### DIFF
--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -188,33 +188,42 @@ async function startElectrodeServer(context) {
         return `with register function`;
       }
     };
-
-    await xaa.map(
-      plugins,
-      async plugin => {
-        try {
-          const x = server.register(plugin.register, plugin.options);
-          await util.promisify(x.after)();
-        } catch (err) {
-          let err2 = err;
-          if (!err || !err.hasOwnProperty("message")) {
-            err2 = new Error(err);
-          } else if (err.code === "ERR_AVVIO_PLUGIN_TIMEOUT") {
-            err2.message = `plugin '${plugin.__name}' with register function timeout \
+    const regFail = (err, plugin) => {
+      let err2 = err;
+      if (!err || !err.hasOwnProperty("message")) {
+        err2 = new Error(err);
+      } else if (err.code === "ERR_AVVIO_PLUGIN_TIMEOUT") {
+        err2.message = `plugin '${plugin.__name}' with register function timeout \
 - did you return a resolved promise?`;
-          }
+      }
+      err2.code = "XPLUGIN_FAILED";
+      err2.plugin = plugin;
+      err2.method = errorRegisterMessage(plugin);
+      return err2;
+    };
 
-          err2.code = "XPLUGIN_FAILED";
-          err2.plugin = plugin;
-          err2.method = errorRegisterMessage(plugin);
-          throw err2;
-        }
-      },
-      // it's important to register all plugins at once before calling server.ready
-      { concurrency: plugins.length }
-    );
+    //
+    // - all register must be called before calling server.ready
+    // - but registration only executed after server.ready is called
+    // - So 1st call must setup all register calls and promises
+    // -    2nd call calls after(), but actual execution wait for server.ready
+    // -    3rd call wait for all registration to complete
+    //
+    const regPromises = plugins.map(plugin => {
+      try {
+        const x = server.register(plugin.register, plugin.options);
+        return util
+          .promisify(x.after)()
+          .catch(err => {
+            throw regFail(err, plugin);
+          });
+      } catch (err) {
+        return Promise.reject(regFail(err, plugin));
+      }
+    });
+    await Promise.all(regPromises);
 
-    await emitEvent(context, "plugins-registered");
+    return emitEvent(context, "plugins-registered");
   };
 
   const handleFail = async err => {

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -210,16 +210,12 @@ async function startElectrodeServer(context) {
     // -    3rd call wait for all registration to complete
     //
     const regPromises = plugins.map(plugin => {
-      try {
-        const x = server.register(plugin.register, plugin.options);
-        return util
-          .promisify(x.after)()
-          .catch(err => {
-            throw regFail(err, plugin);
-          });
-      } catch (err) {
-        return Promise.reject(regFail(err, plugin));
-      }
+      const x = server.register(plugin.register, plugin.options);
+      return util
+        .promisify(x.after)()
+        .catch(err => {
+          throw regFail(err, plugin);
+        });
     });
     await Promise.all(regPromises);
 

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -209,13 +209,13 @@ async function startElectrodeServer(context) {
     // -    2nd call calls after(), but actual execution wait for server.ready
     // -    3rd call wait for all registration to complete
     //
-    const regPromises = plugins.map(plugin => {
-      const x = server.register(plugin.register, plugin.options);
-      return util
-        .promisify(x.after)()
-        .catch(err => {
-          throw regFail(err, plugin);
-        });
+    const regPromises = plugins.map(async plugin => {
+      try {
+        const x = server.register(plugin.register, plugin.options);
+        return await util.promisify(x.after)();
+      } catch (err) {
+        throw regFail(err, plugin);
+      }
     });
     await Promise.all(regPromises);
 


### PR DESCRIPTION
  - All register must be called before calling server.ready
  - but registration only executed after server.ready is called
   - So 1st must setup all register calls and promises
   -      2nd call calls after(), but actual execution wait for server.ready
   -      3rd call wait for all registration to complete
  