### PR TITLE
restore request.path and request.info decorations

### DIFF
--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -304,12 +304,25 @@ module.exports = async function electrodeServer(appConfig = {}, decors) {
   const start = async context => {
     const settings = makeFastifyServerConfig(context);
 
-    context.server = fastify(settings);
+    const server = (context.server = fastify(settings));
 
-    context.server.decorate("settings", settings);
+    // add request.path and request.info as compatibility with Hapi
+    server.decorateRequest("path", {
+      getter() {
+        return this.raw.url.match("^[^?]*")[0];
+      }
+    });
+
+    server.decorateRequest("info", {
+      getter() {
+        return { remoteAddress: this.ip };
+      }
+    });
+
+    server.decorate("settings", settings);
 
     // Register Electrode plugins
-    context.server.register(appContext, { config: context.config });
+    server.register(appContext, { config: context.config });
 
     // Start server
     return startElectrodeServer(context);

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -740,7 +740,7 @@ describe("fastify-server", function () {
     expect(payload).to.equal("/some/path");
   });
 
-  it.skip("gets decorated with request.path that is accessible from hooks", async () => {
+  it("gets decorated with request.path that is accessible from hooks", async () => {
     server = await electrodeServer({ deferStart: true });
     server.addHook("onRequest", (req, reply, done) => {
       reply.send(req.path);
@@ -751,7 +751,7 @@ describe("fastify-server", function () {
     expect(payload).to.equal("/some/path");
   });
 
-  it.skip("gets decorated with request.info.ip (injected request)", async () => {
+  it("gets decorated with request.info.ip (injected request)", async () => {
     server = await electrodeServer({ deferStart: true });
     server.addHook("onRequest", (req, reply, done) => {
       reply.send(req.info.remoteAddress);
@@ -762,7 +762,7 @@ describe("fastify-server", function () {
     expect(resp.text).to.equal("127.0.0.1");
   });
 
-  it.skip("gets decorated with request.info.ip", async () => {
+  it("gets decorated with request.info.ip", async () => {
     server = await electrodeServer({ deferStart: true });
     server.addHook("onRequest", (req, reply, done) => {
       reply.send(req.info.remoteAddress);


### PR DESCRIPTION
since these decorations add no dependencies or extra hot code, they are convenient.
