### PR TITLE
Default connection keep-alive timeout to 60 seconds from Node's 5sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ myConfig.listener = (emitter) => {
 
 - These are async events so you have to take and call a `next` callback.
 
+### keepAliveTimeout (integer)
+
+NodeJS defaults to 5 seconds keep-alive timeout. `fastify-server` defaults to 60 seconds timeout. If you want a custom timeout, use the `keepAliveTimeout` option (in milliseconds).
+
+```json
+{
+  "keepAliveTimeout": 60000
+}
+```
+
 ### logLevel
 
 You can control how much output the Electrode Server logs to the console by setting the `logLevel`.

--- a/lib/electrode-server.js
+++ b/lib/electrode-server.js
@@ -16,6 +16,8 @@ const util = require("util");
 
 const { fastifyPluginDecorate } = require("./fastify-plugin-decorate");
 
+const DEFAULT_KEEPALIVE_TIMEOUT = 60000;
+
 async function emitEvent(context, event) {
   const timeout = _.get(context, "config.electrode.eventTimeout", 10000);
 
@@ -171,7 +173,12 @@ async function convertPluginsToArray(plugins) {
   //
   // transpose each plugin, filter out disabled ones, and sort by priority
   //
-  const pluginsArray = () => _(plugins).map(transpose).filter(isEnable).sortBy(priority).value();
+  const pluginsArray = () =>
+    _(plugins)
+      .map(transpose)
+      .filter(isEnable)
+      .sortBy(priority)
+      .value();
   // convert plugins object to array and check each one if it has a module to load.
   const arr = pluginsArray();
   return xaa.map(arr, loadModule);
@@ -285,7 +292,12 @@ module.exports = async function electrodeServer(appConfig = {}, decors) {
     const fastifyServerConfig = {
       app: {
         electrodeServer: true
-      }
+      },
+      keepAliveTimeout: _.get(
+        context.config,
+        "keepAliveTimeout",
+        _.get(context.config, "electrode.keepAliveTimeout", DEFAULT_KEEPALIVE_TIMEOUT)
+      )
     };
 
     Confippet.util.merge(fastifyServerConfig, context.config.server);

--- a/test/spec/electrode.spec.js
+++ b/test/spec/electrode.spec.js
@@ -11,7 +11,7 @@ const xstdout = require("xstdout");
 
 const HTTP_404 = 404;
 
-describe("fastify-server", function () {
+describe("fastify-server", function() {
   const logLevel = "none";
 
   this.timeout(10000);
@@ -95,6 +95,30 @@ describe("fastify-server", function () {
       });
       await server.start();
     });
+  });
+
+  it("should default keepAliveTimeout to 60 seconds", async () => {
+    server = await electrodeServer({});
+    expect(server.initialConfig.keepAliveTimeout).eq(60000);
+    expect(server.server.keepAliveTimeout).eq(60000);
+  });
+
+  it("can configure keepAliveTimeout", async () => {
+    server = await electrodeServer({
+      keepAliveTimeout: 6001
+    });
+    expect(server.initialConfig.keepAliveTimeout).eq(6001);
+    expect(server.server.keepAliveTimeout).eq(6001);
+  });
+
+  it("can configure keepAliveTimeout using electrode style", async () => {
+    server = await electrodeServer({
+      electrode: {
+        keepAliveTimeout: 6002
+      }
+    });
+    expect(server.initialConfig.keepAliveTimeout).eq(6002);
+    expect(server.server.keepAliveTimeout).eq(6002);
   });
 
   it("should fail for PORT in use", () => {


### PR DESCRIPTION
5 second timeout might cause some gateways to timeout the connection and cause 503s. 60s is more practical.