### PR TITLE
feat: expose fastify handle to user-space

### DIFF
--- a/src/electrode-server.ts
+++ b/src/electrode-server.ts
@@ -391,3 +391,5 @@ export async function electrodeServer<TConfig = any>(
   await emitEvent(ctx, "config-composed");
   return await start(ctx);
 }
+
+export { default as fastify } from 'fastify';


### PR DESCRIPTION
# problem

i want to only have a single fastify dependency in my node_modules, but must have many because:

1. electrode-server is tightly coupled to fastify, but
2. i need a fastify handle for testing, codegen, and other development related tasks which do not warrant a full electrode launch

# solution

expose fastify to userspace