### PR TITLE
refactor: project toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 on:
   push:
-    branches: ['*']
+    branches: ["*"]
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x,16.x,18.x,20.x]
+        node: [14.x, 16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: npm i
-      - run: npm run coverage
+      - run: npm run test
         env:
           CI: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 registry=https://registry.npmjs.org/
-engine-strict=true
+engine-strict=false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# docs †o be purged in separate changeset for less PR thrash
+docs
+CHANGELOG.md
+lib

--- a/README.md
+++ b/README.md
@@ -101,11 +101,10 @@ require("@xarc/fastify-server")({ deferStart: true }).then(server => {
 
 You can pass in a config object that controls every aspect of the Fastify server.
 
-
 ```js
 const config = {
   connection: {
-    port: 9000,
+    port: 9000
   }
 };
 
@@ -153,7 +152,7 @@ All properties are optional (if not present, the default values shown below will
 {
   server: {
     app: {
-      electrode: true;
+      electrode:.toBe(true);
     }
   }
 }
@@ -468,17 +467,21 @@ handler: (request, reply) => {
   console.log("Listening on ", request.app.config.connection.port);
 };
 ```
+
 ## Enable compression
 
 In Fastify compression can be achieved using [@fastify/compress](https://github.com/fastify/fastify-compress#fastifycompress)
+
 ```js
   '@fastify/compress':{
       priority: 200,
-      options: 
-        { global: true, encodings:['gzip'] }    
+      options:
+        { global: true, encodings:['gzip'] }
   },
 ```
+
 Currently, the following encoding tokens are supported, using the first acceptable token in this order:
+
 ```js
 br
 gzip
@@ -486,12 +489,15 @@ deflate
 * (no preference — @fastify/compress will use gzip)
 identity (no compression)
 ```
+
 ## Increase bodyLimit Size
+
 ```js
-    server: {
-    bodyLimit : 1048576//new size limit
-  }
-```  
+server: {
+  bodyLimit: 1048576; //new size limit
+}
+```
+
 ## Contributions
 
 Make sure you sign the CLA. Checkout the [contribution guide](https://github.com/electrode-io/electrode/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ All properties are optional (if not present, the default values shown below will
 {
   server: {
     app: {
-      electrode: true
+      electrode: true;
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This module requires Node v14.x.x+.
 - [API](#api)
   - [electrodeServer](#electrodeserver)
   - [`app` decorator](#app-decorator)
+- [Enable compression](#enable-compression)
+- [Increase bodyLimit Size](#increase-bodylimit-size)
 - [Contributions](#contributions)
 - [License](#license)
 
@@ -152,7 +154,7 @@ All properties are optional (if not present, the default values shown below will
 {
   server: {
     app: {
-      electrode:.toBe(true);
+      electrode: true
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,0 @@
-"use strict";
-
-const dist = require("./lib");
-
-module.exports = (...args) => dist.electrodeServer(...args);
-
-Object.assign(module.exports, dist);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,31 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  collectCoverage: true,
+  coverageThreshold: {
+    global: {
+      statements: 95,
+      branches: 95,
+      functions: 95,
+      lines: 95
+    }
+  },
+  coverageDirectory: "coverage",
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  coverageProvider: "v8",
+  maxWorkers: 1,
+  // testMatch: ["test/**/__tests__/**/*.[jt]s?(x)", "test/**/?(*.)+(spec|test).[tj]s?(x)"]
+  testPathIgnorePatterns: ["/node_modules/", "/lib/", "src/config/test.ts"]
+};
+
+export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,14 +17,8 @@ const config: Config = {
     }
   },
   coverageDirectory: "coverage",
-  // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
-
   coverageProvider: "v8",
   maxWorkers: 1,
-  // testMatch: ["test/**/__tests__/**/*.[jt]s?(x)", "test/**/?(*.)+(spec|test).[tj]s?(x)"]
   testPathIgnorePatterns: ["/node_modules/", "/lib/", "src/config/test.ts"]
 };
 

--- a/package.json
+++ b/package.json
@@ -2,16 +2,18 @@
   "name": "@xarc/fastify-server",
   "version": "4.0.8",
   "description": "A configurable Fastify web server",
-  "main": "index.js",
+  "main": "lib/index.js",
   "types": "./lib/index.d",
   "scripts": {
     "build": "rm -rf lib && tsc",
     "prepublishOnly": "rm -rf lib && tsc && xrun xarc/check",
-    "test": "xrun xarc/test-only",
-    "coverage": "xrun xarc/test-cov",
-    "check": "xrun xarc/check",
-    "sample": "node test/sample/index.js",
-    "docs": "xrun xarc/docs"
+    "test": "jest",
+    "coverage": "jest --collectCoverage",
+    "lint": "eslint",
+    "format": "prettier . --write",
+    "format:check": "prettier . --write",
+    "check": "run-p lint format:check",
+    "sample": "node test/sample/index.js"
   },
   "repository": {
     "type": "git",
@@ -67,77 +69,28 @@
     "xaa": "^1.7.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.22.15",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/chai": "^4.2.14",
+    "@types/jest": "^29.5.11",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.16",
-    "@types/sinon": "^9.0.10",
-    "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "@xarc/module-dev": "^4.0.0",
-    "@xarc/run": "^1.0.4",
-    "@babel/eslint-parser": "^7.22.15",
-    "chai": "^4.2.0",
     "eslint": "^7.16.0",
     "eslint-config-walmart": "^2.2.1",
     "eslint-plugin-filenames": "^1.1.0",
-    "eslint-plugin-jsdoc": "^30.7.9",
-    "eslint-plugin-tsdoc": "^0.2.11",
     "intercept-stdout": "^0.1.2",
+    "jest": "^29.7.0",
     "mitm": "^1.2.0",
-    "mocha": "^10.2.0",
-    "nyc": "^15.1.0",
+    "npm-run-all": "4.1.5",
+    "prettier": "3.2.4",
     "run-verify": "^1.2.1",
-    "sinon": "^17.0.1",
-    "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
     "superagent": "^7.0.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typedoc": "^0.24.8",
-    "typescript": "^5.0.0",
+    "typescript": "^5.3.3",
     "xstdout": "^0.1.1"
-  },
-  "nyc": {
-    "extends": [
-      "@istanbuljs/nyc-config-typescript"
-    ],
-    "all": true,
-    "reporter": [
-      "lcov",
-      "text",
-      "text-summary"
-    ],
-    "exclude": [
-      "*clap.js",
-      "*clap.ts",
-      ".eslintrc.js",
-      "coverage",
-      "dist",
-      "docs",
-      "gulpfile.js",
-      "lib",
-      "test",
-      "xrun*.js",
-      "xrun*.ts",
-      "index.js",
-      "tester"
-    ],
-    "check-coverage": true,
-    "statements": 95,
-    "branches": 95,
-    "functions": 95,
-    "lines": 95,
-    "cache": true
-  },
-  "@xarc/module-dev": {
-    "features": [
-      "eslint",
-      "eslintTS",
-      "mocha",
-      "typedoc",
-      "typescript"
-    ]
   },
   "mocha": {
     "require": [

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "build": "rm -rf lib && tsc",
     "prepublishOnly": "rm -rf lib && tsc && xrun xarc/check",
     "test": "jest",
-    "coverage": "jest --collectCoverage",
     "lint": "eslint",
     "format": "prettier . --write",
-    "format:check": "prettier . --write",
+    "format:check": "prettier . --check",
     "check": "run-p lint format:check",
     "sample": "node test/sample/index.js"
   },

--- a/src/electrode-server.ts
+++ b/src/electrode-server.ts
@@ -194,7 +194,7 @@ async function startElectrodeServer(context): Promise<ElectrodeFastifyInstance> 
     // - all register must be called before calling server.ready
     // - but registration only executed after server.ready is called
     // - So 1st call must setup all register calls and promises
-    // -    2nd call calls after(), but actual execution wait for server.ready
+    // -    2nd call calls afterEach(), but actual execution wait for server.ready
     // -    3rd call wait for all registration to complete
     //
     const regPromises = plugins.map(async plugin => {
@@ -220,7 +220,6 @@ async function startElectrodeServer(context): Promise<ElectrodeFastifyInstance> 
       await context.server.ready();
       await context.registerPluginsPromise;
       await server.listen(<FastifyListenOptions>{
-
         port: config.connection.port,
         host: config.connection.address
       });

--- a/src/electrode-server.ts
+++ b/src/electrode-server.ts
@@ -194,7 +194,7 @@ async function startElectrodeServer(context): Promise<ElectrodeFastifyInstance> 
     // - all register must be called before calling server.ready
     // - but registration only executed after server.ready is called
     // - So 1st call must setup all register calls and promises
-    // -    2nd call calls afterEach(), but actual execution wait for server.ready
+    // -    2nd call calls after(), but actual execution wait for server.ready
     // -    3rd call wait for all registration to complete
     //
     const regPromises = plugins.map(async plugin => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,23 +7,90 @@ import {
 
 /* eslint-disable max-len */
 export type {
-  LightMyRequestChain, InjectOptions, LightMyRequestResponse, LightMyRequestCallback, // 'light-my-request'
-  FastifyRequest, RequestGenericInterface, // './types/request'
+  LightMyRequestChain,
+  InjectOptions,
+  LightMyRequestResponse,
+  LightMyRequestCallback, // 'light-my-request'
+  FastifyRequest,
+  RequestGenericInterface, // './types/request'
   FastifyReply, // './types/reply'
-  FastifyPluginCallback, FastifyPluginAsync, FastifyPluginOptions, FastifyPlugin, // './types/plugin'
-  FastifyListenOptions, FastifyInstance, PrintRoutesOptions, // './types/instance'
-  FastifyLoggerOptions, FastifyBaseLogger, FastifyLoggerInstance, FastifyLogFn, LogLevel, // './types/logger'
-  FastifyRequestContext, FastifyContextConfig, FastifyReplyContext, // './types/context'
-  RouteHandler, RouteHandlerMethod, RouteOptions, RouteShorthandMethod, RouteShorthandOptions, RouteShorthandOptionsWithHandler, RouteGenericInterface, // './types/route'
-  FastifyRegister, FastifyRegisterOptions, RegisterOptions, // './types/register'
-  FastifyBodyParser, FastifyContentTypeParser, AddContentTypeParser, hasContentTypeParser, getDefaultJsonParser, ProtoAction, ConstructorAction, // './types/content-type-parser'
+  FastifyPluginCallback,
+  FastifyPluginAsync,
+  FastifyPluginOptions,
+  FastifyPlugin, // './types/plugin'
+  FastifyListenOptions,
+  FastifyInstance,
+  PrintRoutesOptions, // './types/instance'
+  FastifyLoggerOptions,
+  FastifyBaseLogger,
+  FastifyLoggerInstance,
+  FastifyLogFn,
+  LogLevel, // './types/logger'
+  FastifyRequestContext,
+  FastifyContextConfig,
+  FastifyReplyContext, // './types/context'
+  RouteHandler,
+  RouteHandlerMethod,
+  RouteOptions,
+  RouteShorthandMethod,
+  RouteShorthandOptions,
+  RouteShorthandOptionsWithHandler,
+  RouteGenericInterface, // './types/route'
+  FastifyRegister,
+  FastifyRegisterOptions,
+  RegisterOptions, // './types/register'
+  FastifyBodyParser,
+  FastifyContentTypeParser,
+  AddContentTypeParser,
+  hasContentTypeParser,
+  getDefaultJsonParser,
+  ProtoAction,
+  ConstructorAction, // './types/content-type-parser'
   FastifyError, // '@fastify/error'
-  FastifySchema, FastifySchemaCompiler, // './types/schema'
-  HTTPMethods, RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault, ContextConfigDefault, RequestBodyDefault, RequestQuerystringDefault, RequestParamsDefault, RequestHeadersDefault, // './types/utils'
-  DoneFuncWithErrOrRes, HookHandlerDoneFunction, RequestPayload, onCloseAsyncHookHandler, onCloseHookHandler, onErrorAsyncHookHandler, onErrorHookHandler, onReadyAsyncHookHandler, onReadyHookHandler, onRegisterHookHandler, onRequestAsyncHookHandler, onRequestHookHandler, onResponseAsyncHookHandler, onResponseHookHandler, onRouteHookHandler, onSendAsyncHookHandler, onSendHookHandler, onTimeoutAsyncHookHandler, onTimeoutHookHandler, preHandlerAsyncHookHandler, preHandlerHookHandler, preParsingAsyncHookHandler, preParsingHookHandler, preSerializationAsyncHookHandler, preSerializationHookHandler, preValidationAsyncHookHandler, preValidationHookHandler, // './types/hooks'
-  FastifyServerFactory, FastifyServerFactoryHandler, // './types/serverFactory'
-  FastifyTypeProvider, FastifyTypeProviderDefault, // './types/type-provider'
-  FastifyErrorCodes, // './types/errors'
+  FastifySchema,
+  FastifySchemaCompiler, // './types/schema'
+  HTTPMethods,
+  RawServerBase,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  RawServerDefault,
+  ContextConfigDefault,
+  RequestBodyDefault,
+  RequestQuerystringDefault,
+  RequestParamsDefault,
+  RequestHeadersDefault, // './types/utils'
+  DoneFuncWithErrOrRes,
+  HookHandlerDoneFunction,
+  RequestPayload,
+  onCloseAsyncHookHandler,
+  onCloseHookHandler,
+  onErrorAsyncHookHandler,
+  onErrorHookHandler,
+  onReadyAsyncHookHandler,
+  onReadyHookHandler,
+  onRegisterHookHandler,
+  onRequestAsyncHookHandler,
+  onRequestHookHandler,
+  onResponseAsyncHookHandler,
+  onResponseHookHandler,
+  onRouteHookHandler,
+  onSendAsyncHookHandler,
+  onSendHookHandler,
+  onTimeoutAsyncHookHandler,
+  onTimeoutHookHandler,
+  preHandlerAsyncHookHandler,
+  preHandlerHookHandler,
+  preParsingAsyncHookHandler,
+  preParsingHookHandler,
+  preSerializationAsyncHookHandler,
+  preSerializationHookHandler,
+  preValidationAsyncHookHandler,
+  preValidationHookHandler, // './types/hooks'
+  FastifyServerFactory,
+  FastifyServerFactoryHandler, // './types/serverFactory'
+  FastifyTypeProvider,
+  FastifyTypeProviderDefault, // './types/type-provider'
+  FastifyErrorCodes // './types/errors'
 } from "fastify";
 /* eslint-enable max-len */
 
@@ -32,11 +99,10 @@ export type ServerInfo = {
   port: number;
 };
 
-export interface ElectrodeFastifyInstance
-  extends FastifyInstance {
-    info: ServerInfo;
-    start: () => Promise<any>;
-    app: { config: any } & Record<string, any>;
+export interface ElectrodeFastifyInstance extends FastifyInstance {
+  info: ServerInfo;
+  start: () => Promise<any>;
+  app: { config: any } & Record<string, any>;
 }
 
 /**

--- a/test/dist/html/hello.html
+++ b/test/dist/html/hello.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Hello</title>
-</head>
-<body>
-Hello Test!
-</body>
+  </head>
+  <body>
+    Hello Test!
+  </body>
 </html>

--- a/test/spec/check-node-env.spec.ts
+++ b/test/spec/check-node-env.spec.ts
@@ -1,16 +1,14 @@
 /* eslint-disable */
-
 import { checkNodeEnv } from "../../src/check-node-env";
-import { expect } from "chai";
 
 describe("process-env-abbr", function () {
   let saveEnv;
 
-  before(() => {
+  beforeEach(() => {
     saveEnv = process.env.NODE_ENV;
   });
 
-  after(() => {
+  afterEach(() => {
     if (saveEnv === undefined) {
       delete process.env.NODE_ENV;
     } else {
@@ -39,6 +37,6 @@ describe("process-env-abbr", function () {
     process.env.NODE_ENV = "undefined";
     checkNodeEnv();
     process.stderr.write = w;
-    expect(msg).includes("should be empty or one of");
+    expect(msg).toMatch("should be empty or one of");
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "alwaysStrict": true,
-    "strictFunctionTypes": true,
+    "strictFunctionTypes": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,11 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "declaration": true,
-    "types": ["node", "mocha"],
+    "types": ["node", "jest"],
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "alwaysStrict": true,
-    "strictFunctionTypes": true
+    "strictFunctionTypes": true,
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
 }

--- a/xrun-tasks.ts
+++ b/xrun-tasks.ts
@@ -1,2 +1,0 @@
-import { loadTasks } from "@xarc/module-dev";
-loadTasks();


### PR DESCRIPTION
# Problem

Every JS/TS developer knows common project toolkits (e.g. jest, prettier, etc), but only one JS/TS developer knows xarc/* toolkits.

This is a first pass at improving overall typescript _stuff_ in electrode-fastify-server.

**BREAKING CHANGE**, entrypoint is _nearly_ the same, but the untyped `module.exports(...args)` is **removed**

# Solution

Migrate to latest, common, community oriented tools