### PR TITLE
chore(workflow): remove test runner node v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x, 16.x, 18.x, 20.x]
+        node: [16.x, 18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     "src"
   ],
   "dependencies": {
-    "@fastify/static": "^6.9.0",
+    "@fastify/static": "^7.0.4",
     "async-eventemitter": "^0.2.4",
     "chalk": "^4.1.0",
     "electrode-confippet": "^1.7.0",
-    "fastify": "^4.13.0",
+    "fastify": "^4.29.0",
     "fastify-plugin": "^4.5.0",
     "lodash": "^4.17.21",
     "require-at": "^1.0.6",


### PR DESCRIPTION
- removes 14.x from node matrix job runner
- adds 22.x in node  matrix job runner